### PR TITLE
Updating Microsoft link

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 
             <li><a title="Frontend Masters" href="https://blog.opencollective.com/frontend-masters/"><img src="./logos/frontend-masters.svg" alt="Frontend Masters logo"></a></li>
             <li><a title="Indeed" href="https://github.com/indeedeng/FOSS-Contributor-Fund"><img src="./logos/indeed.svg" alt="Indeed logo"></a></li>
-            <li><a title="Microsoft" href="https://aka.ms/microsoftfossfund"><img src="./logos/microsoft.png" alt="Microsoft logo"></a></li>
+            <li><a title="Microsoft" href="https://opensource.microsoft.com/ecosystem/"><img src="./logos/microsoft.png" alt="Microsoft logo"></a></li>
             <li><a title="Prisma" href="https://prismaio.notion.site/061d28a663464cd6bf39b34ca73f29ab"><img src="./logos/prisma.svg" alt="Prisma logo"></a></li>
             <li><a title="Pydantic" href="https://twitter.com/samuel_colvin/status/1702636501425647640"><img src="./logos/pydantic.svg" alt="Pydantic logo"></a></li>
             <li><a title="Sentry" href="https://blog.sentry.io/we-just-gave-260-028-dollars-to-open-source-maintainers/"><img src="./logos/sentry.svg" alt="Sentry logo"></a></li>


### PR DESCRIPTION
Per Chad's recommendation, using Microsoft's open source ecosystems page vs the FOSS Fund-dedicated page