### PR TITLE
link to Target's durable open source page

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
           <!-- prettier-ignore -->
           <ul class="text">
             <li><a href="https://opensource.googleblog.com/2023/10/finding-stability-in-open-source-work.html">Google</a></li>
-            <li><a href="https://tech.target.com/blog/open-source-fund">Target</a></li>
+            <li><a href="https://tech.target.com/open-source">Target</a></li>
           </ul>
         </div>
       </section>


### PR DESCRIPTION
we just went live with https://tech.target.com/open-source - which links to and celebrates the open source fund and our strategy. 

per "Levels of link awesomeness:" - this is the best one, "The best is a permanent page somewhere on a domain of yours"